### PR TITLE
Support Vault 0.10

### DIFF
--- a/vault-tool/src/Network/VaultTool/Types.hs
+++ b/vault-tool/src/Network/VaultTool/Types.hs
@@ -22,7 +22,13 @@ instance FromJSON VaultAuthToken where
         text <- parseJSON j
         pure (VaultAuthToken text)
 
-newtype VaultSecretPath = VaultSecretPath { unVaultSecretPath :: Text }
+newtype VaultMountedPath = VaultMountedPath { unVaultMountedPath :: Text }
+    deriving (Show, Eq, Ord)
+
+newtype VaultSearchPath = VaultSearchPath { unVaultSearchPath :: Text }
+    deriving (Show, Eq, Ord)
+
+newtype VaultSecretPath = VaultSecretPath (VaultMountedPath, VaultSearchPath)
     deriving (Show, Eq, Ord)
 
 newtype VaultAppRoleId = VaultAppRoleId { unVaultAppRoleId :: Text }


### PR DESCRIPTION
In `vault 0.10`, there're some prefix between `mounted path` and the secret `search path`.
When upgrading from `vault 0.9` to `vault 0.10`, we should separate them for secret engine v2.

(@bitc  I'd like to update the unit test if current implementation is fine. Thanks!)